### PR TITLE
chore: bump pipestream BOM to 0.7.24-SNAPSHOT

### DIFF
--- a/.quarkus/cli/plugins/quarkus-cli-catalog.json
+++ b/.quarkus/cli/plugins/quarkus-cli-catalog.json
@@ -1,5 +1,5 @@
 {
   "version" : "v1",
-  "lastUpdate" : "01/02/2026 14:09:07",
+  "lastUpdate" : "16/04/2026 06:30:20",
   "plugins" : { }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Gradle properties
 
-pipestreamBomVersion=0.7.23
+pipestreamBomVersion=0.7.24-SNAPSHOT
 org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=1g --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED

--- a/src/main/webui/vite.config.ts
+++ b/src/main/webui/vite.config.ts
@@ -1,15 +1,27 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
-export default defineConfig({
-  plugins: [vue()],
-  base: '/admin/',
-  server: {
-    host: 'localhost',
-    port: 5178,
-    strictPort: true,
-  },
-  build: {
-    outDir: 'dist',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  // Extra hostnames the dev server should accept Host headers for.
+  // Comma-separated. Use .env.local (gitignored) for machine-specific
+  // entries like "krick" so they don't land in the committed config.
+  const allowedHosts = env.VITE_ALLOWED_HOSTS
+    ? env.VITE_ALLOWED_HOSTS.split(',').map((h) => h.trim()).filter(Boolean)
+    : undefined
+
+  return {
+    plugins: [vue()],
+    base: '/admin/',
+    server: {
+      host: 'localhost',
+      port: 5178,
+      strictPort: true,
+      ...(allowedHosts ? { allowedHosts } : {}),
+    },
+    build: {
+      outDir: 'dist',
+    },
   }
 })


### PR DESCRIPTION
Consumes the round-robin channel pool + dynamic-grpc counter cache landed in pipestream-platform PR #70 (commit b871a3a, 0.7.24-SNAPSHOT).